### PR TITLE
Oro 6.0.x compatibility added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "OSL-3.0",
     "require": {
         "payplug/payplug-php": "^3.5",
-        "oro/commerce": "5.1.*"
+        "oro/commerce": "6.0.*"
     },
     "repositories": {
         "oro": {

--- a/src/Controller/ConnectionController.php
+++ b/src/Controller/ConnectionController.php
@@ -7,7 +7,7 @@ namespace Payplug\Bundle\PaymentBundle\Controller;
 use Doctrine\Persistence\ManagerRegistry;
 use Oro\Bundle\IntegrationBundle\Entity\Channel;
 use Oro\Bundle\IntegrationBundle\Form\Type\ChannelType;
-use Oro\Bundle\SecurityBundle\Annotation\CsrfProtection;
+use Oro\Bundle\SecurityBundle\Attribute\CsrfProtection;
 use Payplug\Bundle\PaymentBundle\Constant\PayplugSettingsConstant;
 use Payplug\Bundle\PaymentBundle\Entity\PayplugSettings;
 use Payplug\Bundle\PaymentBundle\Service\Gateway;
@@ -16,19 +16,18 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ConnectionController extends AbstractController
 {
     /**
-     * @Route("/login/{channelId}/", name="payplug_login", methods={"POST"})
-     * @ParamConverter("channel", class="OroIntegrationBundle:Channel", options={"id" = "channelId"})
-     * @CsrfProtection()
-     *
      * @throws \InvalidArgumentException
      */
+    #[\Symfony\Component\Routing\Attribute\Route(path: '/login/{channelId}/', name: 'payplug_login', methods: ['POST'])]
+    #[ParamConverter('channel', class: 'OroIntegrationBundle:Channel', options: ['id' => 'channelId'])]
+    #[CsrfProtection]
     public function loginAction(
         Request $request,
         Channel $channel = null,
@@ -79,12 +78,11 @@ class ConnectionController extends AbstractController
     }
 
     /**
-     * @Route("/logout/{channelId}/", name="payplug_logout", methods={"POST"})
-     * @ParamConverter("channel", class="OroIntegrationBundle:Channel", options={"id" = "channelId"})
-     * @CsrfProtection()
-     *
      * @throws \InvalidArgumentException
      */
+    #[\Symfony\Component\Routing\Attribute\Route(path: '/logout/{channelId}/', name: 'payplug_logout', methods: ['POST'])]
+    #[ParamConverter('channel', class: 'OroIntegrationBundle:Channel', options: ['id' => 'channelId'])]
+    #[CsrfProtection]
     public function logoutAction(Request $request, Channel $channel = null, SessionInterface $session, TranslatorInterface $translator, ManagerRegistry $managerRegistry): JsonResponse
     {
         $form = $this->createForm(

--- a/src/Controller/PaymentTransactionController.php
+++ b/src/Controller/PaymentTransactionController.php
@@ -9,15 +9,13 @@ use Payplug\Bundle\PaymentBundle\Method\Provider\PayplugMethodProvider;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class PaymentTransactionController extends AbstractController
 {
-    /**
-     * @Route("/info/{paymentTransactionId}/", name="payplug_payment_transaction_info")
-     * @ParamConverter("paymentTransaction", class="OroPaymentBundle:PaymentTransaction", options={"id" = "paymentTransactionId"})
-     * @Template
-     */
+    #[\Symfony\Component\Routing\Attribute\Route(path: '/info/{paymentTransactionId}/', name: 'payplug_payment_transaction_info')]
+    #[ParamConverter('paymentTransaction', class: 'OroPaymentBundle:PaymentTransaction', options: ['id' => 'paymentTransactionId'])]
+    #[Template]
     public function infoAction(PaymentTransaction $paymentTransaction, PayplugMethodProvider $payplugMethodProvider)
     {
         $paymentMethod = $payplugMethodProvider->getPaymentMethod(

--- a/src/Entity/PayplugSettings.php
+++ b/src/Entity/PayplugSettings.php
@@ -13,85 +13,52 @@ use Payplug\Bundle\PaymentBundle\Constant\PayplugSettingsConstant;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ORM\Entity(repositoryClass="Payplug\Bundle\PaymentBundle\Entity\Repository\PayplugSettingsRepository")
- */
+#[ORM\Entity(repositoryClass: \Payplug\Bundle\PaymentBundle\Entity\Repository\PayplugSettingsRepository::class)]
 class PayplugSettings extends Transport
 {
     /**
      * @var string
-     * @ORM\Column(name="payplug_login", type="string")
      */
+    #[ORM\Column(name: 'payplug_login', type: 'string')]
     protected $login;
 
     /**
      * @var bool
-     * @ORM\Column(name="payplug_debug_mode", type="boolean", options={"default"=false})
      */
+    #[ORM\Column(name: 'payplug_debug_mode', type: 'boolean', options: ['default' => false])]
     protected $debugMode = false;
 
     /**
      * @var string
-     * @ORM\Column(name="payplug_api_key_test", type="string", nullable=true)
      */
+    #[ORM\Column(name: 'payplug_api_key_test', type: 'string', nullable: true)]
     protected $apiKeyTest;
 
     /**
      * @var string
-     * @ORM\Column(name="payplug_api_key_live", type="string", nullable=true)
      */
+    #[ORM\Column(name: 'payplug_api_key_live', type: 'string', nullable: true)]
     protected $apiKeyLive;
 
     /**
      * @var string
-     * @ORM\Column(
-     *     name="payplug_mode",
-     *     type="string",
-     *     nullable=false,
-     *     options={"default" : PayplugSettingsConstant::MODE_TEST}
-     * )
      */
+    #[ORM\Column(name: 'payplug_mode', type: 'string', nullable: false, options: ['default' => PayplugSettingsConstant::MODE_TEST])]
     protected $mode = PayplugSettingsConstant::MODE_TEST;
     /**
      * @var Collection|LocalizedFallbackValue[]
-     *
-     * @ORM\ManyToMany(
-     *      targetEntity="Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue",
-     *      cascade={"ALL"},
-     *      orphanRemoval=true
-     * )
-     * @ORM\JoinTable(
-     *      name="payplug_trans_label",
-     *      joinColumns={
-     *          @ORM\JoinColumn(name="transport_id", referencedColumnName="id", onDelete="CASCADE")
-     *      },
-     *      inverseJoinColumns={
-     *          @ORM\JoinColumn(name="localized_value_id", referencedColumnName="id", onDelete="CASCADE", unique=true)
-     *      }
-     * )
-     * @Assert\NotBlank
      */
+    #[Assert\NotBlank]
+    #[ORM\ManyToMany(targetEntity: \Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue::class, cascade: ['ALL'], orphanRemoval: true)]
+    #[ORM\JoinTable(name: 'payplug_trans_label', joinColumns: [new ORM\JoinColumn(name: 'transport_id', referencedColumnName: 'id', onDelete: 'CASCADE')], inverseJoinColumns: [new ORM\JoinColumn(name: 'localized_value_id', referencedColumnName: 'id', onDelete: 'CASCADE', unique: true)])]
     private $labels;
 
     /**
      * @var Collection|LocalizedFallbackValue[]
-     *
-     * @ORM\ManyToMany(
-     *      targetEntity="Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue",
-     *      cascade={"ALL"},
-     *      orphanRemoval=true
-     * )
-     * @ORM\JoinTable(
-     *      name="payplug_short_label",
-     *      joinColumns={
-     *          @ORM\JoinColumn(name="transport_id", referencedColumnName="id", onDelete="CASCADE")
-     *      },
-     *      inverseJoinColumns={
-     *          @ORM\JoinColumn(name="localized_value_id", referencedColumnName="id", onDelete="CASCADE", unique=true)
-     *      }
-     * )
-     * @Assert\NotBlank
      */
+    #[Assert\NotBlank]
+    #[ORM\ManyToMany(targetEntity: \Oro\Bundle\LocaleBundle\Entity\LocalizedFallbackValue::class, cascade: ['ALL'], orphanRemoval: true)]
+    #[ORM\JoinTable(name: 'payplug_short_label', joinColumns: [new ORM\JoinColumn(name: 'transport_id', referencedColumnName: 'id', onDelete: 'CASCADE')], inverseJoinColumns: [new ORM\JoinColumn(name: 'localized_value_id', referencedColumnName: 'id', onDelete: 'CASCADE', unique: true)])]
     private $shortLabels;
 
     /**

--- a/src/EventListener/Callback/PayplugCheckoutListener.php
+++ b/src/EventListener/Callback/PayplugCheckoutListener.php
@@ -29,7 +29,7 @@ class PayplugCheckoutListener
     protected $refundManager;
 
     /**
-     * @var Session
+     * @var \Symfony\Component\HttpFoundation\RequestStack
      */
     protected $session;
 
@@ -41,7 +41,7 @@ class PayplugCheckoutListener
     public function __construct(
         PaymentMethodProviderInterface $paymentMethodProvider,
         RefundManager $refundManager,
-        Session $session,
+        \Symfony\Component\HttpFoundation\RequestStack $session,
         Logger $logger
     ) {
         $this->paymentMethodProvider = $paymentMethodProvider;

--- a/src/Form/Type/PayplugSettingsType.php
+++ b/src/Form/Type/PayplugSettingsType.php
@@ -138,7 +138,7 @@ class PayplugSettingsType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::BLOCK_PREFIX;
     }

--- a/src/Tests/Unit/Method/Config/PayplugConfigTest.php
+++ b/src/Tests/Unit/Method/Config/PayplugConfigTest.php
@@ -47,7 +47,7 @@ class PayplugConfigTest extends AbstractPaymentConfigTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getPaymentConfig()
+    protected function getPaymentConfig(): \Oro\Bundle\PaymentBundle\Method\Config\PaymentConfigInterface
     {
         $params = [
             PayplugConfig::FIELD_PAYMENT_METHOD_IDENTIFIER => 'test_payment_method_identifier',

--- a/src/Validator/Constraints/CurrencyIsEuro.php
+++ b/src/Validator/Constraints/CurrencyIsEuro.php
@@ -10,12 +10,12 @@ class CurrencyIsEuro extends Constraint
 {
     public $message = 'payplug.constraints.payment_rule.euro_currency';
 
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'payplug.validator.payment_rule.currency_is_euro';
     }
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/src/Validator/Constraints/LocalizedRange.php
+++ b/src/Validator/Constraints/LocalizedRange.php
@@ -20,7 +20,7 @@ class LocalizedRange extends Range
         parent::__construct($options);
     }
 
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return RangeValidator::class;
     }


### PR DESCRIPTION
This PR can be used as a starting point for the extension upgrade.
Most of the changes were done automatically with the upgrade-toolkit tool.

Here is a short list of done changes:
- Updated requirements to oro/commerce 6.0.*
- oro/upgrade-toolkit automatic migrations applied